### PR TITLE
Throw an error message for invalid tickers + allow decimal values for sum to invest

### DIFF
--- a/portfolio_rebalancer/cli.py
+++ b/portfolio_rebalancer/cli.py
@@ -13,7 +13,7 @@ def portfolio_rebalancer():
                                     "your portfolio as close as possible to "
                                     "your target allocation given a sum to "
                                     "invest."))
-@click.argument('sum-to-invest', type=click.INT)
+@click.argument('sum-to-invest', type=click.FLOAT)
 @click.option('-p', '--portfolio', 'portfolio_csv', required=True,
               help="CSV-file containing the portfolio and target allocations.")
 def calc(sum_to_invest, portfolio_csv):

--- a/portfolio_rebalancer/portfolio.py
+++ b/portfolio_rebalancer/portfolio.py
@@ -8,6 +8,10 @@ class Portfolio:
     def __getitem__(self, asset_name):
         return self._assets[asset_name]
 
+    @property
+    def assets(self):
+        return self._assets
+
     def add_asset(self, asset):
         self._total += asset.price * asset.qty
         self._assets[asset.name] = asset

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "portfolio-rebalancer"
-version = "1.0.0"
+version = "1.0.1"
 description = "A CLI tool that shows you what to buy to rebalance your portfolio as best as possible to your target allocations."
 license = "MIT"
 readme = "README.md"


### PR DESCRIPTION
- Print an error message when the portfolio CSV-file contains tickers that
don't exist on Yahoo finance. Fixes #4 
- Allow decimal values to be used for the sum to invest input. Fixes #5 